### PR TITLE
chore(source): Add display name and environment ID to tenant overview

### DIFF
--- a/system/overview.go
+++ b/system/overview.go
@@ -21,7 +21,9 @@ type References struct {
 
 // TenantOverview describes the metadata for a tenant.
 type TenantOverview struct {
-	Identifier string         `json:"identifier"`
-	Version    int64          `json:"version"`
-	Config     *tenant.Config `json:"config,omitempty"`
+	Identifier  string         `json:"identifier"`
+	Name        string         `json:"name"`
+	Environment string         `json:"environment"`
+	Version     int64          `json:"version"`
+	Config      *tenant.Config `json:"config,omitempty"`
 }


### PR DESCRIPTION
No issue

The way source is set up right now is that it makes mapping a tenant display name to the correct tenant ID if multiple environments have tenants with the same display name.

The reason is that the tenant overview returns the information about a tenant, except its display name and environment id, both of which are needed to create a mapping that makes this possible.

This PR will be followed in SE2 as well.