### PR TITLE
fix(request): Grab the request ID from an echo context from the response headers

### DIFF
--- a/request/request.go
+++ b/request/request.go
@@ -62,7 +62,7 @@ func FromEchoContext(c echo.Context) (*CoordinatedRequest, error) {
 	return &CoordinatedRequest{
 		Method:      c.Request().Method,
 		URL:         c.Request().URL.RequestURI(),
-		ID:          c.Request().Header.Get("requestID"),
+		ID:          c.Response().Header().Get(echo.HeaderXRequestID),
 		Body:        reqBody,
 		Headers:     flatHeaders,
 		RespHeaders: map[string]string{},
@@ -85,7 +85,7 @@ func (c *CoordinatedRequest) UseSuborbitalHeaders(ec echo.Context) error {
 		return err
 	}
 
-	ec.Response().Header()[suborbitalRequestIDHeader] = []string{ec.Request().Header.Get("requestID")}
+	ec.Response().Header()[suborbitalRequestIDHeader] = []string{ec.Response().Header().Get(echo.HeaderXRequestID)}
 
 	return nil
 }


### PR DESCRIPTION
No issue.

Running edge functions locally fails because the returned message data is not a coordinated request because [some of the required fields were missing](https://github.com/suborbital/systemspec/blob/main/request/request.go#L159-L161).

Digging into it further, the url, method were present, but the request ID was not.

The uuid request ID middleware was present in the e2core run, and that did appear in the handler.

However the echo request ID middleware, quite cleverly, [puts the request ID in the response headers instead of the request headers](https://github.com/labstack/echo/blob/master/middleware/request_id.go#L65-L68). The idea there is that the incoming request should not be messed with.

This PR adjusts the functionality of systemspec, so when it encounters an echo context, it will extract the request ID from where it actually IS in the context rather than ending up with a false empty string.