### PR TITLE
fix(httpsource): Wrap the actual underlying error into one of our own

### DIFF
--- a/system/client/httpsource.go
+++ b/system/client/httpsource.go
@@ -102,10 +102,10 @@ func (h *HTTPSource) GetModule(FQMN string) (*tenant.Module, error) {
 	module := &tenant.Module{}
 	if err := h.authedGet(path, h.authHeader, module); err != nil {
 		if errors.Is(err, system.ErrAuthenticationFailed) {
-			return nil, system.ErrAuthenticationFailed
+			return nil, errors.Wrap(err, system.ErrAuthenticationFailed.Error())
 		}
 
-		return nil, system.ErrModuleNotFound
+		return nil, errors.Wrap(err, system.ErrModuleNotFound.Error())
 	}
 
 	return module, nil


### PR DESCRIPTION
Issue is on se2: https://github.com/suborbital/se2/issues/1225 <private>

In certain cases the module cannot be found for some reason. We manually verified that the module is there and present, and it _should_ be found, but the function call is returning an error that is not an authentication error, which we blanket turn into a not found error. This makes diagnosing the actual failure very very hard.