### PR TITLE
fix(httpsource): Raise timeout from 2 seconds to 10 seconds in authedget

### DIFF
--- a/system/client/httpsource.go
+++ b/system/client/httpsource.go
@@ -182,7 +182,7 @@ func (h *HTTPSource) authedGet(path, auth string, dest any) error {
 		return errors.Wrap(err, "failed to parsedURL.Parse")
 	}
 
-	ctx, cxl := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cxl := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cxl()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsedURL.String(), nil)


### PR DESCRIPTION
For whatever reason the authedget had a 2 second timeout. Big files apparently take more than 2 seconds to be fetched from the database, and be read into a variable, because we're getting a context deadline exceeded.

Hopefully raising that to 10 seconds would alleviate the issue.